### PR TITLE
Change the way that headings are applied to elements so that they no longer destroy the parent element by replacing the original tag.

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -28,6 +28,21 @@ body {
   font-size: 2em;
 }
 
+.g-body .h1 {
+  font-weight: bold;
+  font-size: 2em;
+}
+
+.g-body .h2 {
+  font-weight: bold;
+  font-size: 1.5em;
+}
+
+.g-body .h3 {
+  font-weight: bold;
+  font-size: 1.17em;
+}
+
 .g-body header {
   font-weight: bold;
   font-size: 52px;

--- a/css/menu.css
+++ b/css/menu.css
@@ -78,6 +78,7 @@
 
 .options.url-mode .header1,
 .options.url-mode .header2,
+.options.url-mode .header3,
 .options.url-mode .bold,
 .options.url-mode .italic,
 .options.url-mode .quote,

--- a/css/menu.css
+++ b/css/menu.css
@@ -62,7 +62,7 @@
   margin-top: -28px;
   z-index: 1000;
   padding: 5px 4px 5px 5px;
-  width: 176px;
+  width: 205px;
   height: 33px;
 
   -webkit-transition: all 300ms ease-in-out;

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
             <button class="italic">i</button>
             <button class="header1">h1</button>
             <button class="header2">h2</button>
+            <button class="header3">h3</button>
             <button class="quote">&rdquo;</button>
             <button class="url useicons">&#xe001;</button>
             <input class="url-input" type="text" placeholder="Paste or type a link"/>

--- a/js/grande.js
+++ b/js/grande.js
@@ -85,6 +85,7 @@
   function reloadMenuState() {
     var className,
         focusNode = getFocusNode(),
+        elemClass = focusNode.parentNode.className,
         tagClass,
         reTag;
 
@@ -96,7 +97,7 @@
         reTag = new RegExp(tagClass);
 
         if (reTag.test(className)) {
-          if (hasParentWithTag(focusNode, tag)) {
+          if (hasParentWithTag(focusNode, tag) || elemClass.match(tag)) {
             node.className = tagClass + " active";
           } else {
             node.className = tagClass;
@@ -189,17 +190,23 @@
       if (reTag.test(className)) {
         switch(tag) {
           case "b":
+            document.execCommand(tagClass, false);
+            return;
           case "i":
             document.execCommand(tagClass, false);
             return;
-
           case "h1":
+            toggleFormatHeading(tag);
+            return;
           case "h2":
+            toggleFormatHeading(tag);
+            return;
           case "h3":
+            toggleFormatHeading(tag);
+            return;
           case "blockquote":
             toggleFormatBlock(tag);
             return;
-
           case "a":
             toggleUrlInput();
             optionsNode.className = "options url-mode";
@@ -248,6 +255,16 @@
     } else {
       document.execCommand("formatBlock", false, tag);
     }
+  }
+
+  function toggleFormatHeading(tag) {
+    node = getFocusNode().parentNode
+    if (node.className.match(tag)) {
+      node.className = node.className.replace(new RegExp('\\b' + tag + '\\b'), '')
+    } else {
+      node.className += ' ' + tag
+    }
+
   }
 
   function toggleUrlInput() {

--- a/js/grande.js
+++ b/js/grande.js
@@ -24,6 +24,7 @@
         "i": "italic",
         "h1": "header1",
         "h2": "header2",
+        "h3": "header3",
         "a": "url",
         "blockquote": "quote"
       };
@@ -190,17 +191,11 @@
       if (reTag.test(className)) {
         switch(tag) {
           case "b":
-            document.execCommand(tagClass, false);
-            return;
           case "i":
             document.execCommand(tagClass, false);
             return;
           case "h1":
-            toggleFormatHeading(tag);
-            return;
           case "h2":
-            toggleFormatHeading(tag);
-            return;
           case "h3":
             toggleFormatHeading(tag);
             return;
@@ -258,11 +253,11 @@
   }
 
   function toggleFormatHeading(tag) {
-    node = getFocusNode().parentNode
+    node = getFocusNode().parentNode;
     if (node.className.match(tag)) {
-      node.className = node.className.replace(new RegExp('\\b' + tag + '\\b'), '')
+      node.className = node.className.replace(new RegExp('\\b' + tag + '\\b'), '').trim();
     } else {
-      node.className += ' ' + tag
+      node.className += ' ' + tag;
     }
   }
 

--- a/js/grande.js
+++ b/js/grande.js
@@ -257,6 +257,8 @@
     if (node.className.match(tag)) {
       node.className = node.className.replace(new RegExp('\\b' + tag + '\\b'), '').trim();
     } else {
+      // Remove existing class and trim
+      node.className = node.className.replace(new RegExp('\\b(h1|h2|h3)\\b'), '').trim();
       node.className += ' ' + tag;
     }
   }

--- a/js/grande.js
+++ b/js/grande.js
@@ -264,7 +264,6 @@
     } else {
       node.className += ' ' + tag
     }
-
   }
 
   function toggleUrlInput() {


### PR DESCRIPTION
Before if someone attempted to add h1 or h2 a `<blockquote>` or `<li>` element, it would wrap the parent element in the selected heading tag. This works fine, until the user attempts to remove the heading, upon which the wrapped element would be replaced with a `<p>` tag, and the `<h1>` tag was left in place.

**To replicate the bug**:
- Select a `<blockquote>` or `<li>` element.
- Click on h1 to add h1 to the selected element.
- Attempt to remove h1 from the selected element.

I've fixed it by adding a `toggleFormatHeading(tag)` function. This function attempts to match the chosen heading `tag` in the selected elements class names. It removes it if it is found, and adds it if it isn't.

I've also added the proper functionality to `reloadMenuState()` to properly check for class names so that the right menu action can be highlighted.

You can see the updated functionality by viewing the gh-pages branch from my fork [here](http://earlcochran.github.io/grande.js/)
