### PR TITLE
Convenient Default: Create .text-menu if not provided by the user

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,22 +11,7 @@
 
   <body class="g-body">
     <a href="https://github.com/mduvall/grande.js"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
-    <div class="text-menu hide">
-      <div class="options">
-        <span class="no-overflow">
-          <span class="ui-inputs">
-            <button class="bold">B</button>
-            <button class="italic">i</button>
-            <button class="header1">h1</button>
-            <button class="header2">h2</button>
-            <button class="quote">&rdquo;</button>
-            <button class="url useicons">&#xe001;</button>
-            <input class="url-input" type="text" placeholder="Paste or type a link"/>
-          </span>
-        </span>
-      </div>
-    </div>
-
+    
     <section>
       <article contenteditable="true" class="content">
         <h1>Welcome, this is grande.js</h1>

--- a/js/grande.js
+++ b/js/grande.js
@@ -1,7 +1,31 @@
 (function() {
   var root = this,   // Root object, this is going to be the window for now
       document = this.document, // Safely store a document here for us to use
-      editableNodes = document.querySelectorAll(".g-body article"),
+      div = document.createElement("div"),
+      html = "<div class='text-menu hide'>    \
+                <div class='options'>         \
+                  <span class='no-overflow'>  \
+                    <span class='ui-inputs'>  \
+                      <button class='bold'>B</button> \
+                      <button class='italic'>i</button> \
+                      <button class='header1'>h1</button> \
+                      <button class='header2'>h2</button> \
+                      <button class='quote'>&rdquo;</button>  \
+                      <button class='url useicons'>&#xe001;</button>  \
+                      <input class='url-input' type='text' placeholder='Paste or type a link'/> \
+                    </span> \
+                  </span> \
+                </div>  \
+              </div>";
+
+  div.innerHTML = html;
+  
+  // If user hasn't provided a .text-menu, insert one into the DOM
+  if (!document.querySelector(".text-menu"))
+    document.body.appendChild(div);
+
+  
+  var editableNodes = document.querySelectorAll(".g-body article"),
       textMenu = document.querySelectorAll(".g-body .text-menu")[0],
       optionsNode = document.querySelectorAll(".g-body .text-menu .options")[0],
       urlInput = document.querySelectorAll(".g-body .text-menu .url-input")[0],


### PR DESCRIPTION
One less thing for user to worry about. Provide a default `.text-menu` and insert into the DOM if user doesn't do it in his HTML.
