### PR TITLE
Implements hr

### DIFF
--- a/js/grande.js
+++ b/js/grande.js
@@ -64,7 +64,17 @@
         triggerTextSelection(event);
       }, 1);
     };
-    document.onkeyup = triggerTextParse;
+    
+    document.onkeyup = function(event){
+      var sel = window.getSelection();
+      
+      // FF will return sel.anchorNode to be the parentNode when the triggered keyCode is 13
+      if (sel.anchorNode && sel.anchorNode.nodeName !== "ARTICLE") {
+        triggerNodeAnalysis(event);
+        
+        if (sel.isCollapsed) triggerTextParse(event);
+      }
+    };
 
     // Handle window resize events
     root.onresize = triggerTextSelection;
@@ -119,7 +129,7 @@
         reTag = new RegExp(tagClass);
 
         if (reTag.test(className)) {
-          if (hasParentWithTag(focusNode, tag)) {
+          if (getParentOfType(focusNode, tag)) {
             node.className = tagClass + " active";
           } else {
             node.className = tagClass;
@@ -131,6 +141,25 @@
     });
   }
 
+  function triggerNodeAnalysis(event) {
+    console.log('analysis');
+    var sel = window.getSelection(),
+        anchorNode,
+        parentP,
+        hr;
+    
+    if (event.keyCode === 13) {
+      parentP = getParentOfType(sel.anchorNode, 'p');
+      	
+      if (sel.anchorNode.nodeName.toLowerCase() === 'p' || parentP) {
+        if (parentP.previousSibling.nodeName.toLowerCase() === 'p' && !parentP.previousSibling.textContent.length) {
+          hr = document.createElement('hr');
+          parentP.parentNode.replaceChild(hr, parentP.previousSibling);
+        }
+      }
+    }
+  }
+
   function triggerTextParse(event) {
     var sel = window.getSelection(),
         textProp,
@@ -140,11 +169,6 @@
         node,
         parent,
         range;
-
-    // FF will return sel.anchorNode to be the parentNode when the triggered keyCode is 13
-    if (!sel.isCollapsed || !sel.anchorNode || sel.anchorNode.nodeName === "ARTICLE") {
-      return;
-    }
 
     if (sel.anchorNode.nodeType === Node.TEXT_NODE) {
       textProp = "data";
@@ -160,26 +184,14 @@
       document.execCommand('insertUnorderedList');
       sel.anchorNode[textProp] = sel.anchorNode[textProp].substring(2);
 
-      insertedNode = sel.anchorNode;
-      while (insertedNode.parentNode) {
-        if (insertedNode.nodeName.toLowerCase() === 'ul') {
-          break;
-        }
-        insertedNode = insertedNode.parentNode;
-      }
+      insertedNode = getParentOfType(sel.anchorNode, 'ul');
     }
 
     if (subject.match(/^1\.\s/) && sel.anchorNode.parentNode.nodeName !== 'LI') {
       document.execCommand('insertOrderedList');
       sel.anchorNode[textProp] = sel.anchorNode[textProp].substring(3);
 
-      insertedNode = sel.anchorNode;
-      while (insertedNode.parentNode) {
-        if (insertedNode.nodeName.toLowerCase() === 'ol') {
-          break;
-        }
-        insertedNode = insertedNode.parentNode;
-      }
+      insertedNode = getParentOfType(sel.anchorNode, 'ol');
     }
 
     unwrap = insertedNode &&
@@ -265,7 +277,7 @@
   }
 
   function toggleFormatBlock(tag) {
-    if (hasParentWithTag(getFocusNode(), tag)) {
+    if (getParentOfType(getFocusNode(), tag)) {
       document.execCommand("formatBlock", false, "p");
       document.execCommand("outdent");
     } else {
@@ -289,14 +301,14 @@
     }, 150);
   }
 
-  function hasParentWithTag(node, nodeType) {
+  function getParentOfType(node, nodeType){
     while (node.parentNode) {
       if (node.nodeName.toLowerCase() === nodeType) {
-        return true;
+        return node;
       }
       node = node.parentNode;
     }
-
+    
     return false;
   }
 


### PR DESCRIPTION
(I don't get why there was such a diff on the previous pull request, but anyway :))

This patch allows inserting hr (#19) by pressing enter when the previous paragraph is empty. In that case the previous paragraph is replaced by the hr. I loosely tested it in the latests chrome, firefox & IE and it works fine. The native deletion of a hr however varies from browser to browser, as mentioned in #20.

Aside from that the patch refactors some not-so-minor things:
- the hr stuff was vastly different from text parsing, so I created a new `triggerNodeAnalysis` function. I think it will become usefull when we address #20 as well
- `triggerTextParse` had some repetition with `triggerNodeAnalysis` so I moved the common code inside an anonymous function called upon `keyup`. This function does the common checkings and then calls the 2 others.
- I renamed and slightly changed the behavior of `hasParentWithTag`. It now returns the first parent element that matches the given type instead of just true. It still works as a test function as previously but is also used in 3 places to grab a parent node.
