### PR TITLE
Fix <hr> insertion on double <p>

### DIFF
--- a/js/grande.js
+++ b/js/grande.js
@@ -194,21 +194,16 @@
         hr;
 
     prevSibling = parentParagraph.previousSibling;
+    prevPrevSibling = prevSibling;
+    
+    while(prevPrevSibling = prevPrevSibling.previousSibling){
+    	if (prevPrevSibling.nodeType != Node.TEXT_NODE) break;
+    }
 
-    if (prevSibling.nodeName === "P" && !prevSibling.textContent.length) {
+    if (prevSibling.nodeName === "P" && !prevSibling.textContent.length && prevPrevSibling.nodeName !== "HR") {
       hr = document.createElement("hr");
       hr.contentEditable = false;
-
-      if (!parentParagraph.textContent.length) {
-        parentParagraph.parentNode.replaceChild(hr, prevSibling);
-        return;
-      }
-
-      // Insert before non-empty <p>
-      prevPrevSibling = parentParagraph.previousSibling.previousSibling;
-      if (prevPrevSibling.nodeName === "P" && !prevPrevSibling.textContent.length) {
-        parentParagraph.parentNode.replaceChild(hr, parentParagraph.previousSibling);
-      }
+      parentParagraph.parentNode.replaceChild(hr, prevSibling);
     }
   }
 


### PR DESCRIPTION
Regarding #27 and #31, it was almost on parity with Medium; I just found a small bug, when pressing enter at the start of a non empty paragraph, preceeded by another non empty paragraph; on Medium this inserts an `hr`, on grande it inserted a regular `p`.

So here's a patch addressing that, but it's probably a good idea to check that it covers all situations.
