### PR TITLE
Avoid conflicts with existing stylesheets by adding specifity to css files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To get up and running simply...
 
 1. Include an `<article>` with `contenteditable`
 2. Include the `grande.js` file at the bottom of your `<body>`
-3. Bind the events on the `document` with `grande.init()`
+3. Bind the events on the `document` with `grande.init()` with an optional `NodeList` to bind to.
 4. You are set!
 
 There are two CSS files that come with the included demo:
@@ -44,3 +44,4 @@ Roadmap
 -------
 - Images (figure)
 - execCommand to support `<strong>` and `<em>`
+- CSS animations to match the `pop-upwards` on Medium

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ To get up and running simply...
 3. Bind the events on the `document` with `grande.init()`
 4. You are set!
 
+### Included files
+
+There are two CSS files that come with the included demo:
+
+- `editor.css`: this file provides the style for the `contenteditable` elements on the page
+- `menu.css`: this file provides the toolbar styling to appear as it does below
+
 ## Options to grande.bind
 
 The `bind` function currently accepts two parameters: bindableNodes and an options list.
@@ -35,11 +42,6 @@ The calling code can pass in a `NodeList` as the first parameter that will bind 
 The second parameter is an `options` object that accepts the following keys:
 
 - `animate`: if true, this will trigger the CSS animations (defaults to true). Useful to turn to false if `subpixel-antialised` is needed in Safari.
-
-There are two CSS files that come with the included demo:
-
-- `editor.css`: this file provides the style for the `contenteditable` elements on the page
-- `menu.css`: this file provides the toolbar styling to appear as it does below
 
 ![image](http://f.cl.ly/items/0O1M1R1g2w1P213C0S3Z/Screen%20Shot%202013-08-21%20at%2011.53.55%20PM.png)
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,18 @@ To get up and running simply...
 
 1. Include an `<article>` with `contenteditable`
 2. Include the `grande.js` file at the bottom of your `<body>`
-3. Bind the events on the `document` with `grande.init()` with an optional `NodeList` to bind to.
+3. Bind the events on the `document` with `grande.init()`
 4. You are set!
+
+## Options to grande.bind
+
+The `bind` function currently accepts two parameters: bindableNodes and an options list.
+
+The calling code can pass in a `NodeList` as the first parameter that will bind to these elements and enable `contentEditable` on them, if nothing is passed in it defaults to elements that match the selector `.g-body article`.
+
+The second parameter is an `options` object that accepts the following keys:
+
+- `animate`: if true, this will trigger the CSS animations (defaults to true). Useful to turn to false if `subpixel-antialised` is needed in Safari.
 
 There are two CSS files that come with the included demo:
 

--- a/css/editor.css
+++ b/css/editor.css
@@ -2,91 +2,70 @@
   font-family: medium-icons;
   src: url("fonts/medium-icons.woff");
 }
-
-body {
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  font-family: Georgia, serif;
-  min-width: 750px;
-  width: 100%;
-  color: #333332;
-  padding-top: 50px;
-}
-
-.g-body h1,
-.g-body p,
-.g-body blockquote,
-.g-body ol,
-.g-body ul {
-  margin-bottom: 15px;
-}
-
-.g-body article {
-  outline-style: none;
-}
-
-/* Override webkit's <article> default */
-.g-body h1 {
-  font-size: 2em;
-}
-
-.g-body header {
-  font-weight: bold;
-  font-size: 52px;
-}
-
 .g-body section {
   max-width: 750px;
   margin: auto;
 }
-
-.g-body blockquote {
+.g-body article {
+  outline-style: none;
+}
+.g-body header {
+  font-weight: bold;
+  font-size: 52px;
+}
+.g-body article h1,
+.g-body article p,
+.g-body article blockquote,
+.g-body article ol,
+.g-body article ul {
+  margin-bottom: 15px;
+}
+.g-body article h1 {
+  /* Override webkit's <article> default */
+  font-size: 2em;
+}
+.g-body article blockquote {
   font-weight: 400;
   font-style: italic;
   border-left: 6px solid #60d778;
   padding-left: 20px;
   margin-left: -26px;
 }
-
-.g-body a {
+.g-body article a {
   text-decoration: underline;
-  color: #333332;
+  color: inherit;
 }
-
-.g-body ol, .g-body ul {
+.g-body article ol,
+.g-body article ul {
   list-style: none;
   list-style-image: none;
   margin-left: 0;
   margin-top: 0;
   padding-left: 0;
 }
-
-.g-body ol li:before,
-.g-body ul li:before {
+.g-body article ol li:before,
+.g-body article ul li:before {
   width: 30px;
   display: inline-block;
 }
-
-.g-body ol {
+.g-body article ol {
   counter-reset: post;
 }
-
-.g-body ol li:before {
+.g-body article ol li:before {
   font-weight: bold;
   counter-increment: post;
   content: counter(post) ".";
 }
-
-.g-body ul li:before {
+.g-body article ul li:before {
   font-family: "medium-icons";
   content: "\e028";
   text-decoration: none;
   font-size: 14px;
 }
-
-.g-body hr {
+.g-body article hr {
   display: block;
   width: 20%;
   margin: 30px auto 20px auto;
-  border: 1px solid #dededc;
+  border-top: 1px solid #dededc;
+  border-bottom: 1px solid #dededc;
 }

--- a/css/editor.css
+++ b/css/editor.css
@@ -2,89 +2,74 @@
   font-family: medium-icons;
   src: url("fonts/medium-icons.woff");
 }
-
-body {
-  font-family: Georgia, serif;
-  min-width: 750px;
-  width: 100%;
-  color: #333332;
-  padding-top: 50px;
-}
-
-.g-body h1,
-.g-body p,
-.g-body blockquote,
-.g-body ol,
-.g-body ul {
-  margin-bottom: 15px;
-}
-
-.g-body article {
-  outline-style: none;
-}
-
-/* Override webkit's <article> default */
-.g-body h1 {
-  font-size: 2em;
-}
-
 .g-body header {
   font-weight: bold;
   font-size: 52px;
 }
-
 .g-body section {
   max-width: 750px;
   margin: auto;
 }
-
-.g-body blockquote {
+.g-body article {
+  outline-style: none;
+}
+.g-body header {
+  font-weight: bold;
+  font-size: 52px;
+}
+.g-body article h1,
+.g-body article p,
+.g-body article blockquote,
+.g-body article ol,
+.g-body article ul {
+  margin-bottom: 15px;
+}
+.g-body article h1 {
+  /* Override webkit's <article> default */
+  font-size: 2em;
+}
+.g-body article blockquote {
   font-weight: 400;
   font-style: italic;
-  border-left:6px solid #e67e22;
+  border-left: 6px solid #e67e22;
   padding-left: 20px;
   margin-left: -26px;
 }
-
-.g-body a {
+.g-body article a {
   text-decoration: underline;
-  color: #333332;
+  color: inherit;
 }
-
-.g-body ol, .g-body ul {
+.g-body article ol,
+.g-body article ul {
   list-style: none;
   list-style-image: none;
   margin-left: 0;
   margin-top: 0;
   padding-left: 0;
 }
-
-.g-body ol li:before,
-.g-body ul li:before {
+.g-body article ol li:before,
+.g-body article ul li:before {
   width: 30px;
   display: inline-block;
 }
-
-.g-body ol {
+.g-body article ol {
   counter-reset: post;
 }
-
-.g-body ol li:before {
+.g-body article ol li:before {
   font-weight: bold;
   counter-increment: post;
   content: counter(post) ".";
 }
-
-.g-body ul li:before {
+.g-body article ul li:before {
   font-family: "medium-icons";
   content: "\e028";
   text-decoration: none;
   font-size: 14px;
 }
-
-.g-body hr {
+.g-body article hr {
   display: block;
   width: 20%;
   margin: 30px auto 20px auto;
-  border: 1px solid #dededc;
+  border-top: 1px solid #dededc;
+  border-bottom: 1px solid #dededc;
 }

--- a/css/editor.css
+++ b/css/editor.css
@@ -2,12 +2,17 @@
   font-family: medium-icons;
   src: url("fonts/medium-icons.woff");
 }
+.g-body {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
 .g-body section {
   max-width: 750px;
   margin: auto;
 }
 .g-body article {
   outline-style: none;
+  font-size: 16px;
 }
 .g-body header {
   font-weight: bold;
@@ -22,7 +27,10 @@
 }
 .g-body article h1 {
   /* Override webkit's <article> default */
-  font-size: 2em;
+  font-size: 32px;
+}
+.g-body article h2 {
+  font-size: 24px;
 }
 .g-body article blockquote {
   font-weight: 400;

--- a/css/menu.css
+++ b/css/menu.css
@@ -3,60 +3,27 @@
   src: url('icomoon/icomoon.ttf'),
        url('icomoon/icomoon.eot');
 }
-
 .g-body .text-menu {
   -webkit-transition: opacity 250ms, margin 250ms;
   -moz-transition: opacity 250ms, margin 250ms;
   -ms-transition: opacity 250ms, margin 250ms;
   -o-transition: opacity 250ms, margin 250ms;
   transition: opacity 250ms, margin 250ms;
-
   position: absolute;
-  color: #fff;
+  color: #ffffff;
   margin-top: -20px;
   margin-left: -115px;
 }
-
-.url {
-  font-size: 16px !important;
-  font-family: 'icomoon' !important;
-}
-
-.text-menu.hide {
+.g-body .text-menu.hide {
   left: -999px;
   top: -999px;
 }
-
-.text-menu.fade {
+.g-body .text-menu.fade {
   opacity: 0;
   margin-top: -5px;
 }
-
-.text-menu .active {
-  color: #e67e22;
-}
-
-.text-menu button {
-  -webkit-transition: opacity 400ms;
-  -moz-transition: opacity 400ms;
-  -ms-transition: opacity 400ms;
-  -o-transition: opacity 400ms;
-  transition: opacity 400ms;
-
-  font-family: inherit;
-  background: none;
-  cursor: pointer;
-  font-size: 16px;
-  color: inherit;
-  padding: 0px;
-  height: 32px;
-  width: 25px;
-  border: 0px;
-  outline: none;
-}
-
-.options {
-  background-color: rgba(0,0,0,0.9);
+.g-body .text-menu .options {
+  background-color: rgba(0, 0, 0, 0.9);
   position: absolute;
   border-radius: 5px;
   margin-left: 23px;
@@ -65,57 +32,67 @@
   padding: 5px 4px 5px 5px;
   width: 176px;
   height: 33px;
-
   -webkit-transition: all 300ms ease-in-out;
   -moz-transition: all 300ms ease-in-out;
   -ms-transition: all 300ms ease-in-out;
   -o-transition: all 300ms ease-in-out;
   transition: all 300ms ease-in-out;
 }
-
-.options.url-mode {
+.g-body .text-menu .options.url-mode {
   width: 176px;
 }
-
-.options.url-mode .header1,
-.options.url-mode .header2,
-.options.url-mode .bold,
-.options.url-mode .italic,
-.options.url-mode .quote,
-.options.url-mode .url {
+.g-body .text-menu .options.url-mode .header1,
+.g-body .text-menu .options.url-mode .header2,
+.g-body .text-menu .options.url-mode .bold,
+.g-body .text-menu .options.url-mode .italic,
+.g-body .text-menu .options.url-mode .quote,
+.g-body .text-menu .options.url-mode .url {
   width: 0px;
   overflow: hidden;
   margin-right: 0px;
   opacity: 0;
 }
-
-.options .italic {
-  font-style: italic;
+.g-body .text-menu .options.url-mode input {
+  border-left: 2px solid transparent;
+  padding-right: 5px;
+  padding-left: 5px;
+  width: 155px;
 }
-
-.options .quote {
-  line-height: 54px !important;
-  font-size: 41px !important;
-}
-
-.options button {
+.g-body .text-menu .options button {
+  -webkit-transition: opacity 400ms;
+  -moz-transition: opacity 400ms;
+  -ms-transition: opacity 400ms;
+  -o-transition: opacity 400ms;
+  transition: opacity 400ms;
+  font-family: inherit;
+  background: none;
+  cursor: pointer;
+  font-size: 16px;
+  color: inherit;
+  padding: 0px;
+  border: 0px;
+  outline: none;
   float: left;
   width: 28px;
   height: 30px;
   border-radius: 3px;
   margin-right: 1px;
 }
-
-.options.url-mode input{
-  border-left: 2px solid transparent;
-  padding-right: 5px;
-  padding-left: 5px;
-  width: 155px;
-  background: transparent;
-  color: #fff;
+.g-body .text-menu .options button.active {
+  color: #e67e22;
 }
-
-.options input {
+.g-body .text-menu .options button.url {
+  font-size: 16px;
+  font-family: 'icomoon';
+}
+.g-body .text-menu .options button.italic {
+  font-style: italic;
+}
+.g-body .text-menu .options button.quote {
+  line-height: 54px;
+  font-size: 41px;
+}
+.g-body .text-menu .options input {
   border-radius: 3px;
   overflow: hidden;
   outline: 0px;
@@ -125,11 +102,12 @@
   border: 0px;
   float: left;
   width: 0px;
+  background: transparent;
+  color: #ffffff;
 }
-
-.options:before {
+.g-body .text-menu .options:before {
   content: "";
-  border-top: 5px solid rgba(0,0,0,0.9);
+  border-top: 5px solid rgba(0, 0, 0, 0.9);
   border-bottom: 5px solid transparent;
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;

--- a/css/menu.css
+++ b/css/menu.css
@@ -60,33 +60,26 @@
   }
 }
 
-.g-body .text-menu {
+.text-menu {
   -webkit-transition: opacity 180ms, margin 180ms;
   -ms-transition: opacity 180ms, margin 180ms;
   transition: opacity 180ms, margin 180ms;
-
   position: absolute;
-  color: #fff;
+  color: #ffffff;
   margin-top: -20px;
   margin-left: -115px;
 }
 
-.g-body .text-menu.active {
+.text-menu.active {
   -webkit-animation:pop-upwards 180ms forwards linear;
   -ms-animation:pop-upwards 180ms forwards linear;
   animation:pop-upwards 180ms forwards linear;
-}
-
-.url {
-  font-size: 16px !important;
-  font-family: 'icomoon' !important;
 }
 
 .text-menu.hide {
   left: -999px;
   top: -999px;
 }
-
 .text-menu.fade {
   opacity: 0;
   margin-top: -5px;
@@ -120,7 +113,7 @@
   user-select: none;
 }
 
-.options {
+.text-menu .options {
   background-color: #262625;
   box-shadow: 0 0 2px #262625;
   position: absolute;
@@ -131,55 +124,65 @@
   padding: 5px 4px 5px 5px;
   width: 176px;
   height: 33px;
-
   -webkit-transition: all 300ms ease-in-out;
   -ms-transition: all 300ms ease-in-out;
   transition: all 300ms ease-in-out;
 }
-
-.options.url-mode {
+.g-body .text-menu .options.url-mode {
   width: 176px;
 }
-
-.options.url-mode .header1,
-.options.url-mode .header2,
-.options.url-mode .bold,
-.options.url-mode .italic,
-.options.url-mode .quote,
-.options.url-mode .url {
+.g-body .text-menu .options.url-mode .header1,
+.g-body .text-menu .options.url-mode .header2,
+.g-body .text-menu .options.url-mode .bold,
+.g-body .text-menu .options.url-mode .italic,
+.g-body .text-menu .options.url-mode .quote,
+.g-body .text-menu .options.url-mode .url {
   width: 0px;
   overflow: hidden;
   margin-right: 0px;
   opacity: 0;
 }
-
-.options .italic {
-  font-style: italic;
+.g-body .text-menu .options.url-mode input {
+  border-left: 2px solid transparent;
+  padding-right: 5px;
+  padding-left: 5px;
+  width: 155px;
 }
-
-.options .quote {
-  line-height: 54px !important;
-  font-size: 41px !important;
-}
-
-.options button {
+.g-body .text-menu .options button {
+  -webkit-transition: opacity 400ms;
+  -moz-transition: opacity 400ms;
+  -ms-transition: opacity 400ms;
+  -o-transition: opacity 400ms;
+  transition: opacity 400ms;
+  font-family: inherit;
+  background: none;
+  cursor: pointer;
+  font-size: 16px;
+  color: inherit;
+  padding: 0px;
+  border: 0px;
+  outline: none;
   float: left;
   width: 28px;
   height: 30px;
   border-radius: 3px;
   margin-right: 1px;
 }
-
-.options.url-mode input{
-  border-left: 2px solid transparent;
-  padding-right: 5px;
-  padding-left: 5px;
-  width: 155px;
-  background: transparent;
-  color: #fff;
+.g-body .text-menu .options button.active {
+  color: #e67e22;
 }
-
-.options input {
+.g-body .text-menu .options button.url {
+  font-size: 16px;
+  font-family: 'icomoon';
+}
+.g-body .text-menu .options button.italic {
+  font-style: italic;
+}
+.g-body .text-menu .options button.quote {
+  line-height: 54px;
+  font-size: 41px;
+}
+.g-body .text-menu .options input {
   border-radius: 3px;
   overflow: hidden;
   outline: 0px;
@@ -189,11 +192,12 @@
   border: 0px;
   float: left;
   width: 0px;
+  background: transparent;
+  color: #ffffff;
 }
-
-.options:before {
+.g-body .text-menu .options:before {
   content: "";
-  border-top: 5px solid rgba(0,0,0,0.9);
+  border-top: 5px solid rgba(0, 0, 0, 0.9);
   border-bottom: 5px solid transparent;
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;

--- a/css/menu.css
+++ b/css/menu.css
@@ -85,11 +85,7 @@
   margin-top: -5px;
 }
 
-.text-menu .active {
-  color: #60d778;
-}
-
-.text-menu button {
+.text-menu .options button {
   -webkit-transition: opacity 400ms;
   -ms-transition: opacity 400ms;
   transition: opacity 400ms;
@@ -100,10 +96,12 @@
   font-size: 16px;
   color: inherit;
   padding: 0px;
-  height: 32px;
-  width: 25px;
+  height: 30px;
+  width: 28px;
   border: 0px;
   outline: none;
+  float: left;
+  margin-right: 1px;
 
   -webkit-touch-callout: none;
   -webkit-user-select: none;
@@ -128,61 +126,36 @@
   -ms-transition: all 300ms ease-in-out;
   transition: all 300ms ease-in-out;
 }
-.g-body .text-menu .options.url-mode {
+.text-menu .options.url-mode {
   width: 176px;
 }
-.g-body .text-menu .options.url-mode .header1,
-.g-body .text-menu .options.url-mode .header2,
-.g-body .text-menu .options.url-mode .bold,
-.g-body .text-menu .options.url-mode .italic,
-.g-body .text-menu .options.url-mode .quote,
-.g-body .text-menu .options.url-mode .url {
+.text-menu .options.url-mode .header1,
+.text-menu .options.url-mode .header2,
+.text-menu .options.url-mode .bold,
+.text-menu .options.url-mode .italic,
+.text-menu .options.url-mode .quote,
+.text-menu .options.url-mode .url {
   width: 0px;
   overflow: hidden;
   margin-right: 0px;
   opacity: 0;
 }
-.g-body .text-menu .options.url-mode input {
-  border-left: 2px solid transparent;
-  padding-right: 5px;
-  padding-left: 5px;
-  width: 155px;
+
+.text-menu .options button.active {
+  color: #60d778;
 }
-.g-body .text-menu .options button {
-  -webkit-transition: opacity 400ms;
-  -moz-transition: opacity 400ms;
-  -ms-transition: opacity 400ms;
-  -o-transition: opacity 400ms;
-  transition: opacity 400ms;
-  font-family: inherit;
-  background: none;
-  cursor: pointer;
-  font-size: 16px;
-  color: inherit;
-  padding: 0px;
-  border: 0px;
-  outline: none;
-  float: left;
-  width: 28px;
-  height: 30px;
-  border-radius: 3px;
-  margin-right: 1px;
-}
-.g-body .text-menu .options button.active {
-  color: #e67e22;
-}
-.g-body .text-menu .options button.url {
+.text-menu .options button.url {
   font-size: 16px;
   font-family: 'icomoon';
 }
-.g-body .text-menu .options button.italic {
+.text-menu .options button.italic {
   font-style: italic;
 }
-.g-body .text-menu .options button.quote {
+.text-menu .options button.quote {
   line-height: 54px;
   font-size: 41px;
 }
-.g-body .text-menu .options input {
+.text-menu .options input {
   border-radius: 3px;
   overflow: hidden;
   outline: 0px;
@@ -190,14 +163,33 @@
   padding: 0px;
   margin: 0px;
   border: 0px;
+  font-size: 12px;
   float: left;
   width: 0px;
   background: transparent;
   color: #ffffff;
+  -webkit-transition: none;
+  -ms-transition: none;
+  transition: none;
 }
-.g-body .text-menu .options:before {
+.text-menu .options.url-mode input {
+  border-left: 2px solid transparent;
+  padding-right: 5px;
+  padding-left: 5px;
+  width: 155px;
+}
+.text-menu .options input:hover,
+.text-menu .options input:focus {
+  -webkit-box-shadow: none;
+  -khtml-box-shadow: none;
+  -moz-box-shadow: none;
+  -ms-box-shadow: none;
+  -o-box-shadow: none;
+  box-shadow: none;
+}
+.text-menu .options:before {
   content: "";
-  border-top: 5px solid rgba(0, 0, 0, 0.9);
+  border-top: 5px solid #262625;
   border-bottom: 5px solid transparent;
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;

--- a/index.html
+++ b/index.html
@@ -4,9 +4,17 @@
     <title>grande.js</title>
     <meta charset="utf-8">
     <meta name="description" content="grande.js: a way for you to express yourself">
-
     <link href="css/menu.css" rel="stylesheet">
     <link href="css/editor.css" rel="stylesheet">
+    <style>
+      body {
+        font-family: Georgia, serif;
+        min-width: 750px;
+        width: 100%;
+        color: #333332;
+        padding-top: 50px;
+      }
+    </style>
   </head>
 
   <body class="g-body">

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         width: 100%;
         color: #333332;
         padding-top: 50px;
+        margin: 0px;
       }
     </style>
   </head>

--- a/js/grande.js
+++ b/js/grande.js
@@ -5,13 +5,16 @@
       document = this.document, // Safely store a document here for us to use
       editableNodes = document.querySelectorAll(".g-body article"),
       isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1,
+      options = {
+        animate: true
+      },
       textMenu,
       optionsNode,
       urlInput,
       previouslySelectedText,
 
       grande = {
-        bind: function(bindableNodes) {
+        bind: function(bindableNodes, opts) {
           if (bindableNodes) {
             editableNodes = bindableNodes;
           }
@@ -19,6 +22,8 @@
           attachToolbarTemplate();
           bindTextSelectionEvents();
           bindTextStylingEvents();
+
+          options = opts || options;
         },
         select: function() {
           triggerTextSelection();
@@ -434,10 +439,12 @@
     textMenu.style.top = top + "px";
     textMenu.style.left = left + "px";
 
-    if (top === EDGE) {
-      textMenu.className = "text-menu hide";
-    } else {
-      textMenu.className = "text-menu active";
+    if (options.animate) {
+      if (top === EDGE) {
+        textMenu.className = "text-menu hide";
+      } else {
+        textMenu.className = "text-menu active";
+      }
     }
   }
 


### PR DESCRIPTION
This pr makes the provided css files more usable straight out of the box (since we can assume that a lot of developers may want to use grande.js as a component rather that a whole body element). Added specifity avoids conflicts with existing stylesheets and obliterates the need of !important flags in rules.

I also moved the body rules from editor.css to index.html since they likely exist for demo purposes only.

The css is an output from .less files with nested rules. I have this build process available in a separate branch if you want to have a look at it (build-process-ideas). There's more than that going on in that branch because I was thinking of a way to release grande.js as a minified and optimized bundle and alternatively give developers the chance to include the .less files directly into their grunt workflow (at least that is my use case). This effectively makes grande.js styles less opinionated and easier to customize.
