### PR TITLE
CSS animations

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -43,7 +43,7 @@ body {
 .g-body blockquote {
   font-weight: 400;
   font-style: italic;
-  border-left:6px solid #e67e22;
+  border-left: 6px solid #60d778;
   padding-left: 20px;
   margin-left: -26px;
 }

--- a/css/editor.css
+++ b/css/editor.css
@@ -4,6 +4,8 @@
 }
 
 body {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
   font-family: Georgia, serif;
   min-width: 750px;
   width: 100%;

--- a/css/menu.css
+++ b/css/menu.css
@@ -7,158 +7,27 @@
 @-webkit-keyframes pop-upwards {
   0% {
     -webkit-transform:matrix(0.97,0,0,1,0,12);
-    -moz-transform:matrix(0.97,0,0,1,0,12);
-    -o-transform:matrix(0.97,0,0,1,0,12);
     transform:matrix(0.97,0,0,1,0,12);
-    filter:alpha(opacity=0);
-    -khtml-opacity:0;
-    -moz-opacity:0;
     opacity:0
   }
   20% {
     -webkit-transform:matrix(0.99,0,0,1,0,2);
-    -moz-transform:matrix(0.99,0,0,1,0,2);
-    -o-transform:matrix(0.99,0,0,1,0,2);
     transform:matrix(0.99,0,0,1,0,2);
-    filter:alpha(opacity=70);
-    -khtml-opacity:.7;
-    -moz-opacity:.7;
     opacity:.7
   }
   40% {
     -webkit-transform:matrix(1,0,0,1,0,-1);
-    -moz-transform:matrix(1,0,0,1,0,-1);
-    -o-transform:matrix(1,0,0,1,0,-1);
     transform:matrix(1,0,0,1,0,-1);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
     opacity:1
   }
   70% {
     -webkit-transform:matrix(1,0,0,1,0,0);
-    -moz-transform:matrix(1,0,0,1,0,0);
-    -o-transform:matrix(1,0,0,1,0,0);
     transform:matrix(1,0,0,1,0,0);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
     opacity:1
   }
   100% {
     -webkit-transform:matrix(1,0,0,1,1,1);
-    -moz-transform:matrix(1,0,0,1,0,0);
-    -o-transform:matrix(1,0,0,1,0,0);
     transform:matrix(1,0,0,1,0,0);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
-    opacity:1
-  }
-}
-
-@-moz-keyframes pop-upwards{
-  0% {
-    -webkit-transform:matrix(0.97,0,0,1,0,12);
-    -moz-transform:matrix(0.97,0,0,1,0,12);
-    -o-transform:matrix(0.97,0,0,1,0,12);
-    transform:matrix(0.97,0,0,1,0,12);
-    filter:alpha(opacity=0);
-    -khtml-opacity:0;
-    -moz-opacity:0;
-    opacity:0
-  }
-  20% {
-    -webkit-transform:matrix(0.99,0,0,1,0,2);
-    -moz-transform:matrix(0.99,0,0,1,0,2);
-    -o-transform:matrix(0.99,0,0,1,0,2);
-    transform:matrix(0.99,0,0,1,0,2);
-    filter:alpha(opacity=70);
-    -khtml-opacity:.7;
-    -moz-opacity:.7;
-    opacity:.7
-  }
-  40% {
-    -webkit-transform:matrix(1,0,0,1,0,-1);
-    -moz-transform:matrix(1,0,0,1,0,-1);
-    -o-transform:matrix(1,0,0,1,0,-1);
-    transform:matrix(1,0,0,1,0,-1);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
-    opacity:1
-  }
-  70% {
-    -webkit-transform:matrix(1,0,0,1,0,0);
-    -moz-transform:matrix(1,0,0,1,0,0);
-    -o-transform:matrix(1,0,0,1,0,0);
-    transform:matrix(1,0,0,1,0,0);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
-    opacity:1
-  }
-  100% {
-    -webkit-transform:matrix(1,0,0,1,0,0);
-    -moz-transform:matrix(1,0,0,1,0,0);
-    -o-transform:matrix(1,0,0,1,0,0);
-    transform:matrix(1,0,0,1,0,0);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
-    opacity:1
-  }
-}
-
-@-o-keyframes pop-upwards {
-  0% {
-    -webkit-transform:matrix(0.97,0,0,1,0,12);
-    -moz-transform:matrix(0.97,0,0,1,0,12);
-    -o-transform:matrix(0.97,0,0,1,0,12);
-    transform:matrix(0.97,0,0,1,0,12);
-    filter:alpha(opacity=0);
-    -khtml-opacity:0;
-    -moz-opacity:0;
-    opacity:0
-  }
-  20% {
-    -webkit-transform:matrix(0.99,0,0,1,0,2);
-    -moz-transform:matrix(0.99,0,0,1,0,2);
-    -o-transform:matrix(0.99,0,0,1,0,2);
-    transform:matrix(0.99,0,0,1,0,2);
-    filter:alpha(opacity=70);
-    -khtml-opacity:.7;
-    -moz-opacity:.7;
-    opacity:.7
-  }
-  40% {
-    -webkit-transform:matrix(1,0,0,1,0,-1);
-    -moz-transform:matrix(1,0,0,1,0,-1);
-    -o-transform:matrix(1,0,0,1,0,-1);
-    transform:matrix(1,0,0,1,0,-1);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
-    opacity:1
-  }
-  70% {
-    -webkit-transform:matrix(1,0,0,1,0,0);
-    -moz-transform:matrix(1,0,0,1,0,0);
-    -o-transform:matrix(1,0,0,1,0,0);
-    transform:matrix(1,0,0,1,0,0);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
-    opacity:1
-  }
-  100% {
-    -webkit-transform:matrix(1,0,0,1,0,0);
-    -moz-transform:matrix(1,0,0,1,0,0);
-    -o-transform:matrix(1,0,0,1,0,0);
-    transform:matrix(1,0,0,1,0,0);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
     opacity:1
   }
 }
@@ -166,61 +35,34 @@
 @keyframes pop-upwards{
   0% {
     -webkit-transform:matrix(0.97,0,0,1,0,12);
-    -moz-transform:matrix(0.97,0,0,1,0,12);
-    -o-transform:matrix(0.97,0,0,1,0,12);
     transform:matrix(0.97,0,0,1,0,12);
-    filter:alpha(opacity=0);
-    -khtml-opacity:0;
-    -moz-opacity:0;
     opacity:0
   }
   20% {
     -webkit-transform:matrix(0.99,0,0,1,0,2);
-    -moz-transform:matrix(0.99,0,0,1,0,2);
-    -o-transform:matrix(0.99,0,0,1,0,2);
     transform:matrix(0.99,0,0,1,0,2);
-    filter:alpha(opacity=70);
-    -khtml-opacity:.7;
-    -moz-opacity:.7;
     opacity:.7
   }
   40% {
     -webkit-transform:matrix(1,0,0,1,0,-1);
-    -moz-transform:matrix(1,0,0,1,0,-1);
-    -o-transform:matrix(1,0,0,1,0,-1);
     transform:matrix(1,0,0,1,0,-1);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
     opacity:1
   }
   70% {
     -webkit-transform:matrix(1,0,0,1,0,0);
-    -moz-transform:matrix(1,0,0,1,0,0);
-    -o-transform:matrix(1,0,0,1,0,0);
     transform:matrix(1,0,0,1,0,0);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
     opacity:1
   }
   100% {
     -webkit-transform:matrix(1,0,0,1,0,0);
-    -moz-transform:matrix(1,0,0,1,0,0);
-    -o-transform:matrix(1,0,0,1,0,0);
     transform:matrix(1,0,0,1,0,0);
-    filter:alpha(opacity=100);
-    -khtml-opacity:1;
-    -moz-opacity:1;
     opacity:1
   }
 }
 
 .g-body .text-menu {
   -webkit-transition: opacity 180ms, margin 180ms;
-  -moz-transition: opacity 180ms, margin 180ms;
   -ms-transition: opacity 180ms, margin 180ms;
-  -o-transition: opacity 180ms, margin 180ms;
   transition: opacity 180ms, margin 180ms;
 
   position: absolute;
@@ -231,9 +73,7 @@
 
 .g-body .text-menu.active {
   -webkit-animation:pop-upwards 180ms forwards linear;
-  -moz-animation:pop-upwards 180ms forwards linear;
   -ms-animation:pop-upwards 180ms forwards linear;
-  -o-animation:pop-upwards 180ms forwards linear;
   animation:pop-upwards 180ms forwards linear;
 }
 
@@ -258,9 +98,7 @@
 
 .text-menu button {
   -webkit-transition: opacity 400ms;
-  -moz-transition: opacity 400ms;
   -ms-transition: opacity 400ms;
-  -o-transition: opacity 400ms;
   transition: opacity 400ms;
 
   font-family: inherit;
@@ -283,7 +121,8 @@
 }
 
 .options {
-  background-color: rgba(0,0,0,0.9);
+  background-color: #262625;
+  box-shadow: 0 0 2px #262625;
   position: absolute;
   border-radius: 5px;
   margin-left: 23px;
@@ -294,9 +133,7 @@
   height: 33px;
 
   -webkit-transition: all 300ms ease-in-out;
-  -moz-transition: all 300ms ease-in-out;
   -ms-transition: all 300ms ease-in-out;
-  -o-transition: all 300ms ease-in-out;
   transition: all 300ms ease-in-out;
 }
 

--- a/css/menu.css
+++ b/css/menu.css
@@ -93,7 +93,7 @@
 }
 
 .text-menu .active {
-  color: #e67e22;
+  color: #60d778;
 }
 
 .text-menu button {

--- a/css/menu.css
+++ b/css/menu.css
@@ -4,6 +4,218 @@
        url('icomoon/icomoon.eot');
 }
 
+@-webkit-keyframes pop-upwards {
+  0% {
+    -webkit-transform:matrix(0.97,0,0,1,0,12);
+    -moz-transform:matrix(0.97,0,0,1,0,12);
+    -o-transform:matrix(0.97,0,0,1,0,12);
+    transform:matrix(0.97,0,0,1,0,12);
+    filter:alpha(opacity=0);
+    -khtml-opacity:0;
+    -moz-opacity:0;
+    opacity:0
+  }
+  20% {
+    -webkit-transform:matrix(0.99,0,0,1,0,2);
+    -moz-transform:matrix(0.99,0,0,1,0,2);
+    -o-transform:matrix(0.99,0,0,1,0,2);
+    transform:matrix(0.99,0,0,1,0,2);
+    filter:alpha(opacity=70);
+    -khtml-opacity:.7;
+    -moz-opacity:.7;
+    opacity:.7
+  }
+  40% {
+    -webkit-transform:matrix(1,0,0,1,0,-1);
+    -moz-transform:matrix(1,0,0,1,0,-1);
+    -o-transform:matrix(1,0,0,1,0,-1);
+    transform:matrix(1,0,0,1,0,-1);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+  70% {
+    -webkit-transform:matrix(1,0,0,1,0,0);
+    -moz-transform:matrix(1,0,0,1,0,0);
+    -o-transform:matrix(1,0,0,1,0,0);
+    transform:matrix(1,0,0,1,0,0);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+  100% {
+    -webkit-transform:matrix(1,0,0,1,0,0);
+    -moz-transform:matrix(1,0,0,1,0,0);
+    -o-transform:matrix(1,0,0,1,0,0);
+    transform:matrix(1,0,0,1,0,0);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+}
+
+@-moz-keyframes pop-upwards{
+  0% {
+    -webkit-transform:matrix(0.97,0,0,1,0,12);
+    -moz-transform:matrix(0.97,0,0,1,0,12);
+    -o-transform:matrix(0.97,0,0,1,0,12);
+    transform:matrix(0.97,0,0,1,0,12);
+    filter:alpha(opacity=0);
+    -khtml-opacity:0;
+    -moz-opacity:0;
+    opacity:0
+  }
+  20% {
+    -webkit-transform:matrix(0.99,0,0,1,0,2);
+    -moz-transform:matrix(0.99,0,0,1,0,2);
+    -o-transform:matrix(0.99,0,0,1,0,2);
+    transform:matrix(0.99,0,0,1,0,2);
+    filter:alpha(opacity=70);
+    -khtml-opacity:.7;
+    -moz-opacity:.7;
+    opacity:.7
+  }
+  40% {
+    -webkit-transform:matrix(1,0,0,1,0,-1);
+    -moz-transform:matrix(1,0,0,1,0,-1);
+    -o-transform:matrix(1,0,0,1,0,-1);
+    transform:matrix(1,0,0,1,0,-1);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+  70% {
+    -webkit-transform:matrix(1,0,0,1,0,0);
+    -moz-transform:matrix(1,0,0,1,0,0);
+    -o-transform:matrix(1,0,0,1,0,0);
+    transform:matrix(1,0,0,1,0,0);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+  100% {
+    -webkit-transform:matrix(1,0,0,1,0,0);
+    -moz-transform:matrix(1,0,0,1,0,0);
+    -o-transform:matrix(1,0,0,1,0,0);
+    transform:matrix(1,0,0,1,0,0);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+}
+
+@-o-keyframes pop-upwards {
+  0% {
+    -webkit-transform:matrix(0.97,0,0,1,0,12);
+    -moz-transform:matrix(0.97,0,0,1,0,12);
+    -o-transform:matrix(0.97,0,0,1,0,12);
+    transform:matrix(0.97,0,0,1,0,12);
+    filter:alpha(opacity=0);
+    -khtml-opacity:0;
+    -moz-opacity:0;
+    opacity:0
+  }
+  20% {
+    -webkit-transform:matrix(0.99,0,0,1,0,2);
+    -moz-transform:matrix(0.99,0,0,1,0,2);
+    -o-transform:matrix(0.99,0,0,1,0,2);
+    transform:matrix(0.99,0,0,1,0,2);
+    filter:alpha(opacity=70);
+    -khtml-opacity:.7;
+    -moz-opacity:.7;
+    opacity:.7
+  }
+  40% {
+    -webkit-transform:matrix(1,0,0,1,0,-1);
+    -moz-transform:matrix(1,0,0,1,0,-1);
+    -o-transform:matrix(1,0,0,1,0,-1);
+    transform:matrix(1,0,0,1,0,-1);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+  70% {
+    -webkit-transform:matrix(1,0,0,1,0,0);
+    -moz-transform:matrix(1,0,0,1,0,0);
+    -o-transform:matrix(1,0,0,1,0,0);
+    transform:matrix(1,0,0,1,0,0);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+  100% {
+    -webkit-transform:matrix(1,0,0,1,0,0);
+    -moz-transform:matrix(1,0,0,1,0,0);
+    -o-transform:matrix(1,0,0,1,0,0);
+    transform:matrix(1,0,0,1,0,0);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+}
+
+@keyframes pop-upwards{
+  0% {
+    -webkit-transform:matrix(0.97,0,0,1,0,12);
+    -moz-transform:matrix(0.97,0,0,1,0,12);
+    -o-transform:matrix(0.97,0,0,1,0,12);
+    transform:matrix(0.97,0,0,1,0,12);
+    filter:alpha(opacity=0);
+    -khtml-opacity:0;
+    -moz-opacity:0;
+    opacity:0
+  }
+  20% {
+    -webkit-transform:matrix(0.99,0,0,1,0,2);
+    -moz-transform:matrix(0.99,0,0,1,0,2);
+    -o-transform:matrix(0.99,0,0,1,0,2);
+    transform:matrix(0.99,0,0,1,0,2);
+    filter:alpha(opacity=70);
+    -khtml-opacity:.7;
+    -moz-opacity:.7;
+    opacity:.7
+  }
+  40% {
+    -webkit-transform:matrix(1,0,0,1,0,-1);
+    -moz-transform:matrix(1,0,0,1,0,-1);
+    -o-transform:matrix(1,0,0,1,0,-1);
+    transform:matrix(1,0,0,1,0,-1);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+  70% {
+    -webkit-transform:matrix(1,0,0,1,0,0);
+    -moz-transform:matrix(1,0,0,1,0,0);
+    -o-transform:matrix(1,0,0,1,0,0);
+    transform:matrix(1,0,0,1,0,0);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+  100% {
+    -webkit-transform:matrix(1,0,0,1,0,0);
+    -moz-transform:matrix(1,0,0,1,0,0);
+    -o-transform:matrix(1,0,0,1,0,0);
+    transform:matrix(1,0,0,1,0,0);
+    filter:alpha(opacity=100);
+    -khtml-opacity:1;
+    -moz-opacity:1;
+    opacity:1
+  }
+}
+
 .g-body .text-menu {
   -webkit-transition: opacity 250ms, margin 250ms;
   -moz-transition: opacity 250ms, margin 250ms;
@@ -15,6 +227,14 @@
   color: #fff;
   margin-top: -20px;
   margin-left: -115px;
+}
+
+.g-body .text-menu.active {
+  -webkit-animation:pop-upwards 180ms forwards linear;
+  -moz-animation:pop-upwards 180ms forwards linear;
+  -ms-animation:pop-upwards 180ms forwards linear;
+  -o-animation:pop-upwards 180ms forwards linear;
+  animation:pop-upwards 180ms forwards linear;
 }
 
 .url {

--- a/css/menu.css
+++ b/css/menu.css
@@ -217,11 +217,11 @@
 }
 
 .g-body .text-menu {
-  -webkit-transition: opacity 250ms, margin 250ms;
-  -moz-transition: opacity 250ms, margin 250ms;
-  -ms-transition: opacity 250ms, margin 250ms;
-  -o-transition: opacity 250ms, margin 250ms;
-  transition: opacity 250ms, margin 250ms;
+  -webkit-transition: opacity 180ms, margin 180ms;
+  -moz-transition: opacity 180ms, margin 180ms;
+  -ms-transition: opacity 180ms, margin 180ms;
+  -o-transition: opacity 180ms, margin 180ms;
+  transition: opacity 180ms, margin 180ms;
 
   position: absolute;
   color: #fff;

--- a/css/menu.css
+++ b/css/menu.css
@@ -46,7 +46,7 @@
     opacity:1
   }
   100% {
-    -webkit-transform:matrix(1,0,0,1,0,0);
+    -webkit-transform:matrix(1,0,0,1,1,1);
     -moz-transform:matrix(1,0,0,1,0,0);
     -o-transform:matrix(1,0,0,1,0,0);
     transform:matrix(1,0,0,1,0,0);
@@ -273,6 +273,13 @@
   width: 25px;
   border: 0px;
   outline: none;
+
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .options {

--- a/js/grande.js
+++ b/js/grande.js
@@ -1,4 +1,6 @@
 (function() {
+  var EDGE = -999;
+
   var root = this,   // Root object, this is going to be the window for now
       document = this.document, // Safely store a document here for us to use
       editableNodes = document.querySelectorAll(".g-body article"),
@@ -413,7 +415,8 @@
 
       // The selected text is collapsed, push the menu out of the way
       if (selectedText.isCollapsed) {
-        setTextMenuPosition(-999, -999);
+        setTextMenuPosition(EDGE, EDGE);
+        textMenu.className = "text-menu hide";
       } else {
         range = selectedText.getRangeAt(0);
         clientRectBounds = range.getBoundingClientRect();
@@ -430,6 +433,12 @@
   function setTextMenuPosition(top, left) {
     textMenu.style.top = top + "px";
     textMenu.style.left = left + "px";
+
+    if (top === EDGE) {
+      textMenu.className = "text-menu hide";
+    } else {
+      textMenu.className = "text-menu active";
+    }
   }
 
   root.grande = grande;


### PR DESCRIPTION
Fixes https://github.com/mduvall/grande.js/issues/35.

Introduces a potential visual regression where CSS `transform`s turn the `font-smoothing` from `subpixel-antialiased` to `antialiased` and may make the menu text look thinner.
