### PR TITLE
Add separate toolbar class to prevent style clash

### DIFF
--- a/js/grande.js
+++ b/js/grande.js
@@ -58,7 +58,11 @@
             </span> \
           </span> \
         </div>",
-        imageTooltipTemplate = document.createElement("div");
+        imageTooltipTemplate = document.createElement("div"),
+        toolbarContainer = document.createElement("div");
+
+    toolbarContainer.className = "g-body";
+    document.body.appendChild(toolbarContainer);
 
     imageTooltipTemplate.innerHTML = "<div class='pos-abs file-label'>Insert image</div> \
                                         <input class='file-hidden pos-abs' type='file' id='files' name='files[]' accept='image/*' multiple/>";
@@ -68,8 +72,8 @@
     div.innerHTML = toolbarTemplate;
 
     if (document.querySelectorAll(".text-menu").length === 0) {
-      document.body.appendChild(div);
-      document.body.appendChild(imageTooltipTemplate);
+      toolbarContainer.appendChild(div);
+      toolbarContainer.appendChild(imageTooltipTemplate);
     }
 
     imageInput = document.querySelectorAll(".file-label + input")[0];


### PR DESCRIPTION
The problem is that if you use `editor.css` as it is you are expected to have `<body class="g-class">` to make a toolbar work properly because toolbar styling relates on this fact.

Now you can have something like that:

```
<div class="g-class">
  <article contenteditable="true"></article>
</div>
```

Toolbar will be appended not inside `document.body` but inside special `<div class="g-body">` placed in the bottom of the `document.body`. This assures that any external CSS won't break the toolbar.
