### PR TITLE
Disable menu when non-editable text is selected

### DIFF
--- a/js/grande.js
+++ b/js/grande.js
@@ -521,7 +521,12 @@
     return getParent(node, checkHref, returnHref);
   }
 
-  function triggerTextSelection() {
+  function triggerTextSelection(e) {
+      // The selected text is not editable
+      if (!e.srcElement.isContentEditable) {
+          return false;
+      }
+
       var selectedText = root.getSelection(),
           range,
           clientRectBounds;


### PR DESCRIPTION
When making only part of a site editable the menu should only open on editable parts. The changes in this PR check whether the Source Element is editable - if not, it returns false instead of continuing.

**How to replicate**
1. Create a example page with an `<article>` and an `<aside>` element - both with text content
2. Bind grande.js with `g.bind(document.querySelectorAll('article');`
3. Select text _outside_ of `<article>` but _within_ `<aside>`

![screenshot-grandejs-bug](https://f.cloud.github.com/assets/698963/1501009/f805917e-4883-11e3-8124-459a20e747ea.png)

When clicking a option on a non-editable node, An _Uncaught TypeError: Cannot read property 'parentNode' of null_ gets thrown.

Thanks for making grande.js - it's really awesome to use.
