### PR TITLE
Fix selection being cancelled in triggerTextSelection()

### DIFF
--- a/js/grande.js
+++ b/js/grande.js
@@ -524,7 +524,7 @@
   function triggerTextSelection(e) {
       // The selected text is not editable
       if (!e.srcElement.isContentEditable) {
-          return false;
+          return;
       }
 
       var selectedText = root.getSelection(),


### PR DESCRIPTION
Fix for issue where returning false was killing the selection event for non-Grande.js elements.
