### PR TITLE
Check for node is null, before node.parentNode

### DIFF
--- a/js/grande.js
+++ b/js/grande.js
@@ -494,6 +494,9 @@
   }
 
   function getParent(node, condition, returnCallback) {
+    if (node === null){
+      return;
+    }
     while (node.parentNode) {
       if (condition(node)) {
         return returnCallback(node);


### PR DESCRIPTION
Checks that the 'node' variable passed to getParent() function isn't null.

Might be a quirk of how I'm using Grande.js, but kept getting bombarded with these null errors. This little check fixed it up for me.
