### PR TITLE
Small improvements

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -6,11 +6,6 @@
 body {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
-  font-family: Georgia, serif;
-  min-width: 750px;
-  width: 100%;
-  color: #333332;
-  padding-top: 50px;
 }
 
 .g-body h1,

--- a/js/grande.js
+++ b/js/grande.js
@@ -535,8 +535,19 @@
         clientRectBounds,
         target = e.target || e.srcElement;
 
-    // The selected text is not editable
-    if (!target.isContentEditable) {
+    // Check whether user clicks outside contenteditable AND outside menu
+    var isContentEditable = false;
+    var parentTarget = target;
+    while (parentTarget) {
+      if (parentTarget.isContentEditable || parentTarget === textMenu) {
+        isContentEditable = true;
+        break;
+      }
+      parentTarget = parentTarget.parentElement;
+    }
+
+    // The selected text is not editable and is neither the menu, so hide the menu
+    if (!isContentEditable) {
       setTextMenuPosition(EDGE, EDGE);
       textMenu.className = "text-menu hide";
       return;

--- a/js/grande.js
+++ b/js/grande.js
@@ -235,7 +235,9 @@
   function bindTextStylingEvents() {
     iterateTextMenuButtons(function(node) {
       node.onmousedown = function(event) {
-        triggerTextStyling(node);
+        if (event.which == 1) {
+          triggerTextStyling(node);
+        }
       };
     });
   }

--- a/js/grande.js
+++ b/js/grande.js
@@ -543,7 +543,7 @@
     }
 
     // The selected text is collapsed, push the menu out of the way
-    if (selectedText.isCollapsed) {
+    if (selectedText.isCollapsed || selectedText.getRangeAt(0).toString().match(/^\s+$/g)) {
       setTextMenuPosition(EDGE, EDGE);
       textMenu.className = "text-menu hide";
     } else {

--- a/js/grande.js
+++ b/js/grande.js
@@ -537,7 +537,8 @@
 
     // The selected text is not editable
     if (!target.isContentEditable) {
-      reloadMenuState();
+      setTextMenuPosition(EDGE, EDGE);
+      textMenu.className = "text-menu hide";
       return;
     }
 


### PR DESCRIPTION
I removed standard CSS from the body tag, it interferes with my styling and it is unnecessary.
Menu now hides when clicking outside the editor. I believe this is expected behaviour, I myself kept clicking outside only to note the menu never hides that way. Which is weird...
Unable to select whitespace, you can't and shouldn't apply styling to whitespace.
Clicking a button in menu now only works with the left mousebutton, this is expected and default button behaviour.

What I think should be implemented is that selected text is trimmed of whitespace at the beginning and end. So if you select "Hello " it will style "Hello" and exclude the trailing whitespace.
