### PR TITLE
Added event param to getHorizontalBounds

### DIFF
--- a/js/grande.js
+++ b/js/grande.js
@@ -141,7 +141,7 @@
     var childrenNodes = editNode.children,
         editBounds = editNode.getBoundingClientRect();
 
-    imageBound = getHorizontalBounds(childrenNodes, editBounds);
+    imageBound = getHorizontalBounds(childrenNodes, editBounds, event);
   }
 
   function uploadImage(event) {
@@ -164,7 +164,7 @@
   function toggleImageTooltip(event, element) {
     var childrenNodes = editNode.children,
         editBounds = editNode.getBoundingClientRect(),
-        bound = getHorizontalBounds(childrenNodes, editBounds);
+        bound = getHorizontalBounds(childrenNodes, editBounds, event);
 
     if (bound) {
       imageTooltip.style.left = (editBounds.left - 90 ) + "px";
@@ -175,7 +175,7 @@
     }
   }
 
-  function getHorizontalBounds(nodes, target) {
+  function getHorizontalBounds(nodes, target, event) {
     var bounds = [],
         bound,
         i,


### PR DESCRIPTION
Firefox (v30) errors on getHorizontalBounds() because **event** is out of scope. This occurs when **allowImages** is enabled, and causes the Insert Image tool tip to not work. 

Request to add **event** to the parameters of getHorizontalBounds()!

Btw, can someone explain why in chrome **event** is _not_ undefined at 
_coordY = event.pageY - root.scrollY;_ 
(line 206 in getHorizontalBounds())? Is it just being generous with the scope, or is it supposed to work like that?
