### PR TITLE
Add hash to url regex

### DIFF
--- a/js/grande.js
+++ b/js/grande.js
@@ -454,7 +454,7 @@
       return false;
     }
 
-    if (!url.match("^(http://|https://|mailto:)")) {
+    if (!url.match("^(http://|https://|#|mailto:)")) {
       url = "http://" + url;
     }
 


### PR DESCRIPTION
Linking to `#section` automatically prepends `http://`, expected behaviour would be to leave it as is to allow linking to anchors
